### PR TITLE
Fixed MT25TL01G_Enter4BytesAddressMode waiting loop

### DIFF
--- a/mt25tl01g.c
+++ b/mt25tl01g.c
@@ -84,7 +84,7 @@ int32_t MT25TL01G_Enter4BytesAddressMode(QSPI_HandleTypeDef *Ctx, MT25TL01G_Inte
   }
 
   /* Configure automatic polling mode to wait the memory is ready */
-  else if(MT25TL01G_AutoPollingMemReady(Ctx,Mode)!=MT25TL01G_OK)
+  else if(MT25TL01G_AutoPollingMemReady(Ctx,MT25TL01G_QPI_MODE)!=MT25TL01G_OK)
   {
     return MT25TL01G_ERROR_COMMAND;
   }


### PR DESCRIPTION
After we pushed command
's_command.Instruction       = MT25TL01G_ENTER_4_BYTE_ADDR_MODE_CMD;'
We have to wait in MT25TL01G_QPI_MODE mode

## IMPORTANT INFORMATION

Pull-requests are **not** accepted on this repository. Please use issues to report any bug or request.
